### PR TITLE
Modify default summary function type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { Plugin } from 'rollup';
+
 declare interface SummaryPrint {
     Name: string;
     Size: string;
@@ -56,4 +58,4 @@ declare interface SummaryOptions {
  * Prints out a summary of the rollup build
  * @param {SummaryOptions} options Summary plugin options
  */
-export default function summary(options: SummaryOptions): void;
+export default function summary(options?: SummaryOptions): Plugin;

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "rollup-plugin-filesize": "^9.0.2"
     },
     "peerDependencies": {
+        "rollup": "^2.0.0",
         "as-table": "^1.0.55",
         "chalk": "^4.1.0",
         "rollup-plugin-filesize": "^9.0.2"


### PR DESCRIPTION
Fixes #34 & #35 by making the options argument optional and setting the return type to the rollup Plugin interface.